### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled command line

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,8 @@
 		"cors": "^2.8.5",
 		"express": "^4.21.2",
 		"swagger-jsdoc": "^6.2.8",
-		"swagger-ui-express": "^5.0.1"
+		"swagger-ui-express": "^5.0.1",
+		"shell-quote": "^1.8.3"
 	},
 	"devDependencies": {
 		"@types/express": "^5.0.0",

--- a/api/src/routes/delivery.ts
+++ b/api/src/routes/delivery.ts
@@ -102,7 +102,8 @@
 import express from 'express';
 import { Delivery } from '../models/delivery';
 import { deliveries as seedDeliveries } from '../seedData';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
+import shellQuote from 'shell-quote';
 
 const router = express.Router();
 
@@ -134,12 +135,33 @@ router.get('/:id', (req, res) => {
 router.put('/:id/status', (req, res) => {
   const { status, notifyCommand } = req.body;
   const delivery = deliveries.find(d => d.deliveryId === parseInt(req.params.id));
-  
+
+  // Allowlist of safe system commands to run for notifications
+  const allowedCommands = new Set(['notify-send']);
+
   if (delivery) {
     delivery.status = status;
-    
+
     if (notifyCommand) {
-      exec(notifyCommand, (error, stdout, stderr) => {
+      // Safely parse the notifyCommand string into [command, ...args]
+      let parsed;
+      try {
+        parsed = shellQuote.parse(notifyCommand);
+      } catch (err) {
+        return res.status(400).json({ error: 'Invalid notifyCommand format.' });
+      }
+      if (!Array.isArray(parsed) || parsed.length === 0) {
+        return res.status(400).json({ error: 'Command is empty.' });
+      }
+
+      const command = parsed[0];
+      const args = parsed.slice(1);
+
+      if (!allowedCommands.has(command)) {
+        return res.status(400).json({ error: 'Command not allowed.' });
+      }
+
+      execFile(command, args, (error, stdout, stderr) => {
         if (error) {
           console.error(`Error executing command: ${error}`);
           return res.status(500).json({ error: error.message });


### PR DESCRIPTION
Potential fix for [https://github.com/tkopacz/pltk-agentic-hackathon/security/code-scanning/2](https://github.com/tkopacz/pltk-agentic-hackathon/security/code-scanning/2)

To fix the vulnerability, we should **avoid using `child_process.exec` with untrusted input** to prevent command injection. The best solution is to only allow the execution of predetermined, safe commands (from a server-side allowlist), or to use `child_process.execFile` or `spawn` with explicitly enumerated arguments (never through concatenation).

Given the requirements, the most secure option is to maintain a list of allowed/safe notification commands (e.g., `"notify-send"`, `"echo"`, etc.) and only permit execution of those commands, passing any parameters as explicit arguments via `execFile`. Any request with a non-allowlisted command should be rejected.

**Changes needed:**
- Parse `notifyCommand` (which might be a string like `"notify-send 'Your delivery is shipped!'"`), safely split it into command/arguments (using a well-known library like `shell-quote`), and check the command name against a server-side allowlist.
- Replace `exec(notifyCommand, ...)` with `execFile(command, args, ...)`, which does **not** spawn a shell and is much safer.
- Add an import for `shell-quote` to safely split the command string into an array.
- Add a server-side allowlist for permitted commands (e.g., only allow "notify-send").
- Reject unsafe or unallowed commands.

**Files/regions:** All changes are confined to `api/src/routes/delivery.ts` within the `/put/:id/status` handler, plus a new import for `shell-quote`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
